### PR TITLE
Fix MSVC flag in AMBuildScript

### DIFF
--- a/extension/AMBuildScript
+++ b/extension/AMBuildScript
@@ -225,7 +225,7 @@ class ExtensionConfig(object):
       if cxx.like('gcc'):
         cxx.cflags += ['-O3']
       elif cxx.like('msvc'):
-        cxx.cflags += ['/Ox', '/Zo', '/Oi', '/GL', '\Ot']
+        cxx.cflags += ['/Ox', '/Zo', '/Oi', '/GL', '/Ot']
         cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
 
     # Debugging


### PR DESCRIPTION
The backslash caused the build to fail since cl.exe interpreted it as a filename as opposed to a compiler flag.